### PR TITLE
Include image URLs when returning Activity JSON

### DIFF
--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -27,6 +27,16 @@ class Activity extends Model
         'location_lng',
     ];
 
+    /** Estos atributos virtuales se incluirán automáticamente
+     *  cuando el modelo se serialice a JSON. De esta forma las
+     *  URLs de las imágenes estarán disponibles en las respuestas
+     *  del API sin necesidad de transformaciones adicionales. */
+    protected $appends = [
+        'selfie_url',
+        'device_image_url',
+        'attachments_url',
+    ];
+
     protected $casts = [
         'attachments'   => 'array',
         'location_lat'  => 'decimal:6',


### PR DESCRIPTION
## Summary
- expose public URLs for activity images via appended attributes

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c280ad4483288b979c41b57c4528