### PR TITLE
Fix CoinFits award logic

### DIFF
--- a/app/Observers/ActivityObserver.php
+++ b/app/Observers/ActivityObserver.php
@@ -5,6 +5,8 @@ namespace App\Observers;
 use App\Models\Activity;
 use App\Services\FitcoinService;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Carbon;
+use App\Models\FitcoinTransaction;
 
 class ActivityObserver
 {
@@ -25,11 +27,15 @@ class ActivityObserver
         $metaSteps = config("coinfits.levels.{$level}.steps", 0);
         $metaMins  = config("coinfits.levels.{$level}.minutes", 0);
 
+        // Convertir la duración a minutos para la evaluación
+        $durationMinutes = $activity->duration_unit === 'horas'
+            ? $activity->duration * 60
+            : $activity->duration;
+
         // 1) Cumplió pasos **y** minutos activos?
         if (
             $activity->steps >= $metaSteps
-            && $activity->duration >= $metaMins
-            && $activity->duration_unit === 'minutos'
+            && $durationMinutes >= $metaMins
         ) {
             $awarded += 10;
         }
@@ -50,6 +56,38 @@ class ActivityObserver
                 $awarded,
                 "Actividad ID {$activity->id}"
             );
+        }
+
+        // 4) Bono semanal por cumplir 5 días o más
+        $startOfWeek = Carbon::now()->startOfWeek();
+        $endOfWeek   = Carbon::now()->endOfWeek();
+
+        $daysMet = Activity::where('user_id', $activity->user_id)
+            ->whereBetween('created_at', [$startOfWeek, $endOfWeek])
+            ->get()
+            ->groupBy(fn($a) => $a->created_at->toDateString())
+            ->filter(function ($acts) use ($metaSteps, $metaMins) {
+                foreach ($acts as $act) {
+                    $minutes = $act->duration_unit === 'horas'
+                        ? $act->duration * 60
+                        : $act->duration;
+                    if ($act->steps >= $metaSteps && $minutes >= $metaMins) {
+                        return true;
+                    }
+                }
+                return false;
+            })
+            ->count();
+
+        if ($daysMet >= 5) {
+            $bonusDesc = 'Bono semanal ' . $startOfWeek->toDateString();
+            $exists = FitcoinTransaction::where('fitcoin_account_id', $col->fitcoinAccount->id ?? 0)
+                ->where('description', $bonusDesc)
+                ->exists();
+
+            if (! $exists) {
+                $this->fitcoin->award($col, 10, $bonusDesc);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- convert activity duration to minutes before evaluating goals
- add weekly bonus for reaching goals on 5+ days

## Testing
- `php artisan test --testsuite=Feature --stop-on-failure` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68545a3275e8832885d146f91d146960