### PR TITLE
Implement daily and weekly Fitcoin rewards

### DIFF
--- a/app/Observers/ActivityObserver.php
+++ b/app/Observers/ActivityObserver.php
@@ -5,6 +5,7 @@ namespace App\Observers;
 use App\Models\Activity;
 use App\Services\FitcoinService;
 use Illuminate\Support\Facades\Config;
+use Carbon\Carbon;
 
 class ActivityObserver
 {
@@ -18,30 +19,42 @@ class ActivityObserver
     public function created(Activity $activity)
     {
         $col = $activity->user->colaborator;
-        if (! $col) return;
+        if (! $col) {
+            return;
+        }
 
-        $awarded   = 0;
         $level     = $col->nivel_asignado;
         $metaSteps = config("coinfits.levels.{$level}.steps", 0);
         $metaMins  = config("coinfits.levels.{$level}.minutes", 0);
 
-        // 1) Cumplió pasos **y** minutos activos?
-        if (
-            $activity->steps >= $metaSteps
+        $meetsGoal = $activity->steps >= $metaSteps
             && $activity->duration >= $metaMins
-            && $activity->duration_unit === 'minutos'
-        ) {
+            && $activity->duration_unit === 'minutos';
+
+        $startDay = Carbon::parse($activity->created_at)->startOfDay();
+        $endDay   = Carbon::parse($activity->created_at)->endOfDay();
+
+        // Verificar si ya se registró una actividad válida hoy
+        $alreadyMetToday = Activity::where('user_id', $activity->user_id)
+            ->where('id', '<', $activity->id)
+            ->whereBetween('created_at', [$startDay, $endDay])
+            ->where('steps', '>=', $metaSteps)
+            ->where('duration', '>=', $metaMins)
+            ->where('duration_unit', 'minutos')
+            ->exists();
+
+        $awarded = 0;
+
+        if ($meetsGoal && ! $alreadyMetToday) {
             $awarded += 10;
-        }
 
-        // 2) Evidencia (foto o ubicación)
-        if ($activity->selfie_path || $activity->location_lat) {
-            $awarded += 2;
-        }
+            if ($activity->selfie_path || $activity->location_lat) {
+                $awarded += 2;
+            }
 
-        // 3) Superó la meta de pasos
-        if ($activity->steps > $metaSteps) {
-            $awarded += 3;
+            if ($activity->steps > $metaSteps) {
+                $awarded += 3;
+            }
         }
 
         if ($awarded > 0) {
@@ -50,6 +63,39 @@ class ActivityObserver
                 $awarded,
                 "Actividad ID {$activity->id}"
             );
+        }
+
+        // Evaluar bono semanal si esta actividad aportó para la meta diaria
+        if ($meetsGoal && ! $alreadyMetToday) {
+            $weekStart = $startDay->copy()->startOfWeek();
+            $weekEnd   = $startDay->copy()->endOfWeek();
+
+            $daysMet = Activity::where('user_id', $activity->user_id)
+                ->whereBetween('created_at', [$weekStart, $weekEnd])
+                ->where('steps', '>=', $metaSteps)
+                ->where('duration', '>=', $metaMins)
+                ->where('duration_unit', 'minutos')
+                ->selectRaw('DATE(created_at) as day')
+                ->groupBy('day')
+                ->get()
+                ->count();
+
+            if ($daysMet >= 5) {
+                $bonusExists = $col->fitcoinAccount
+                    ? $col->fitcoinAccount->transactions()
+                        ->where('description', 'like', 'Bono semanal%')
+                        ->whereBetween('created_at', [$weekStart, $weekEnd])
+                        ->exists()
+                    : false;
+
+                if (! $bonusExists) {
+                    $this->fitcoin->award(
+                        $col,
+                        10,
+                        'Bono semanal ' . $weekStart->format('Y-m-d')
+                    );
+                }
+            }
         }
     }
 }

--- a/app/Observers/ActivityObserver.php
+++ b/app/Observers/ActivityObserver.php
@@ -6,20 +6,25 @@ use App\Models\Activity;
 use App\Services\FitcoinService;
 use Illuminate\Support\Carbon;
 use App\Models\FitcoinTransaction;
-use Illuminate\Support\Facades\Config;
+        $previousActs = Activity::where('user_id', $activity->user_id)
+            ->get();
 
-class ActivityObserver
-{
-    protected $fitcoin;
+        $prevSteps = $previousActs->sum('steps');
+        $prevMinutes = $previousActs->sum(function ($act) {
+            return $act->duration_unit === 'horas'
+                ? $act->duration * 60
+                : $act->duration;
+        });
 
-    public function __construct(FitcoinService $fitcoin)
-    {
-        $this->fitcoin = $fitcoin;
-    }
+        $goalMetBefore = $prevSteps >= $metaSteps && $prevMinutes >= $metaMins;
 
-    public function created(Activity $activity)
-    {
-        $col = $activity->user->colaborator;
+        $totalSteps = $prevSteps + $activity->steps;
+        $totalMinutes = $prevMinutes + $activityMinutes;
+
+        $goalMetNow = $totalSteps >= $metaSteps && $totalMinutes >= $metaMins;
+        if (! $goalMetBefore && $goalMetNow) {
+            if ($totalSteps > $metaSteps) {
+        if (! $goalMetBefore && $goalMetNow) {
         if (! $col) {
             return;
         }


### PR DESCRIPTION
## Summary
- limit daily award to the first activity that meets the goal
- add weekly bonus of 10 CoinFits when goals met 5 times in a week
- update `ActivityObserver` logic accordingly

## Testing
- `composer test` *(fails: `composer: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68545aba5c488328a6a1ce38ae5190dd