### PR TITLE
Add FCM dependency and image support for general info

### DIFF
--- a/app/Http/Controllers/Api/WebAdmin/GeneralInfoController.php
+++ b/app/Http/Controllers/Api/WebAdmin/GeneralInfoController.php
@@ -19,6 +19,7 @@ class GeneralInfoController extends Controller
             'title' => 'required|string',
             'content' => 'required|string',
             'category' => 'nullable|string',
+            'image_path' => 'nullable|string',
         ]);
 
         $info = GeneralInfo::create($data);
@@ -36,6 +37,7 @@ class GeneralInfoController extends Controller
             'title' => 'sometimes|required|string',
             'content' => 'sometimes|required|string',
             'category' => 'nullable|string',
+            'image_path' => 'nullable|string',
         ]);
 
         $info->update($data);

--- a/app/Models/GeneralInfo.php
+++ b/app/Models/GeneralInfo.php
@@ -13,5 +13,6 @@ class GeneralInfo extends Model
         'title',
         'content',
         'category',
+        'image_path',
     ];
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
-        "laravel/tinker": "^2.8"
+        "laravel/tinker": "^2.8",
+        "notification-channels/fcm": "^5.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/database/migrations/2025_07_01_000002_add_image_path_to_general_infos_table.php
+++ b/database/migrations/2025_07_01_000002_add_image_path_to_general_infos_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('general_infos', function (Blueprint $table) {
+            $table->string('image_path')->nullable()->after('category');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('general_infos', function (Blueprint $table) {
+            $table->dropColumn('image_path');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- include `notification-channels/fcm` in the composer requirements
- allow saving an optional `image_path` on general info
- expose the new field via the model and controller
- add database migration to store the image path

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d6076a3988328ac335b2fa4a91538