### PR TITLE
Add file uploads to GeneralInfo

### DIFF
--- a/app/Http/Controllers/Api/WebAdmin/GeneralInfoController.php
+++ b/app/Http/Controllers/Api/WebAdmin/GeneralInfoController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\WebAdmin;
 use App\Http\Controllers\Controller;
 use App\Models\GeneralInfo;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 class GeneralInfoController extends Controller
 {
@@ -15,14 +16,30 @@ class GeneralInfoController extends Controller
 
     public function store(Request $request)
     {
-        $data = $request->validate([
-            'title' => 'required|string',
-            'content' => 'required|string',
-            'category' => 'nullable|string',
-            'image_path' => 'nullable|string',
+        $validated = $request->validate([
+            'title'       => 'required|string',
+            'content'     => 'required|string',
+            'category'    => 'nullable|string',
+            'image'       => 'sometimes|file|image|mimes:jpeg,png,jpg,gif|max:2048',
+            'image_path'  => 'sometimes|file|image|mimes:jpeg,png,jpg,gif|max:2048',
+            'video'       => 'sometimes|file|mimes:mp4,mov,avi,wmv|max:20480',
+            'video_path'  => 'sometimes|file|mimes:mp4,mov,avi,wmv|max:20480',
         ]);
 
+        $data = collect($validated)->only(['title', 'content', 'category'])->all();
+
+        $imageFile = $request->file('image') ?? $request->file('image_path');
+        if ($imageFile) {
+            $data['image_path'] = $imageFile->store('general_images', 'public');
+        }
+
+        $videoFile = $request->file('video') ?? $request->file('video_path');
+        if ($videoFile) {
+            $data['video_path'] = $videoFile->store('general_videos', 'public');
+        }
+
         $info = GeneralInfo::create($data);
+
         return response()->json($info, 201);
     }
 
@@ -33,20 +50,51 @@ class GeneralInfoController extends Controller
 
     public function update(Request $request, GeneralInfo $info)
     {
-        $data = $request->validate([
-            'title' => 'sometimes|required|string',
-            'content' => 'sometimes|required|string',
-            'category' => 'nullable|string',
-            'image_path' => 'nullable|string',
+        $validated = $request->validate([
+            'title'       => 'sometimes|required|string',
+            'content'     => 'sometimes|required|string',
+            'category'    => 'nullable|string',
+            'image'       => 'sometimes|file|image|mimes:jpeg,png,jpg,gif|max:2048',
+            'image_path'  => 'sometimes|file|image|mimes:jpeg,png,jpg,gif|max:2048',
+            'video'       => 'sometimes|file|mimes:mp4,mov,avi,wmv|max:20480',
+            'video_path'  => 'sometimes|file|mimes:mp4,mov,avi,wmv|max:20480',
         ]);
 
+        $data = collect($validated)->only(['title', 'content', 'category'])->all();
+
+        $imageFile = $request->file('image') ?? $request->file('image_path');
+        if ($imageFile) {
+            if ($info->image_path) {
+                Storage::disk('public')->delete($info->image_path);
+            }
+            $data['image_path'] = $imageFile->store('general_images', 'public');
+        }
+
+        $videoFile = $request->file('video') ?? $request->file('video_path');
+        if ($videoFile) {
+            if ($info->video_path) {
+                Storage::disk('public')->delete($info->video_path);
+            }
+            $data['video_path'] = $videoFile->store('general_videos', 'public');
+        }
+
         $info->update($data);
+
         return response()->json($info);
     }
 
     public function destroy(GeneralInfo $info)
     {
+        if ($info->image_path) {
+            Storage::disk('public')->delete($info->image_path);
+        }
+
+        if ($info->video_path) {
+            Storage::disk('public')->delete($info->video_path);
+        }
+
         $info->delete();
+
         return response()->json(null, 204);
     }
 }

--- a/app/Models/GeneralInfo.php
+++ b/app/Models/GeneralInfo.php
@@ -14,5 +14,32 @@ class GeneralInfo extends Model
         'content',
         'category',
         'image_path',
+        'video_path',
     ];
+
+    /** Estos atributos virtuales se incluirán en las respuestas JSON */
+    protected $appends = [
+        'image_url',
+        'video_url',
+    ];
+
+    /**
+     * Obtiene la URL pública de la imagen
+     */
+    public function getImageUrlAttribute(): ?string
+    {
+        return $this->image_path
+            ? \Illuminate\Support\Facades\Storage::url($this->image_path)
+            : null;
+    }
+
+    /**
+     * Obtiene la URL pública del video
+     */
+    public function getVideoUrlAttribute(): ?string
+    {
+        return $this->video_path
+            ? \Illuminate\Support\Facades\Storage::url($this->video_path)
+            : null;
+    }
 }

--- a/database/migrations/2025_07_01_000004_add_video_path_to_general_infos_table.php
+++ b/database/migrations/2025_07_01_000004_add_video_path_to_general_infos_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('general_infos', function (Blueprint $table) {
+            $table->string('video_path')->nullable()->after('image_path');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('general_infos', function (Blueprint $table) {
+            $table->dropColumn('video_path');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- support video_path column for general information
- append image/video URLs in GeneralInfo model
- handle image and video uploads in GeneralInfoController
- allow uploads via either `image` or `image_path` and `video` or `video_path`

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685eb7d36c4483288719667d25414de0