### PR TITLE
Switch to internal notifications

### DIFF
--- a/app/Notifications/EjercicioReminder.php
+++ b/app/Notifications/EjercicioReminder.php
@@ -1,24 +1,24 @@
 <?php
 // app/Notifications/EjercicioReminder.php
 namespace App\Notifications;
+
 use Illuminate\Notifications\Notification;
-use NotificationChannels\Fcm\FcmChannel;
-use NotificationChannels\Fcm\FcmMessage;
-use NotificationChannels\Fcm\Resources\Notification as FcmNotif;
 
 class EjercicioReminder extends Notification
 {
     public function __construct(protected $title, protected $body) {}
 
-    public function via($notifiable) { return [FcmChannel::class]; }
-
-    public function toFcm($notifiable)
+    public function via($notifiable)
     {
-        return FcmMessage::create()
-            ->setNotification(FcmNotif::create()
-                ->setTitle($this->title)
-                ->setBody($this->body)
-            )
-            ->setData(['action'=>'reminder_exercise']);
+        return ['database'];
+    }
+
+    public function toArray($notifiable)
+    {
+        return [
+            'title'  => $this->title,
+            'body'   => $this->body,
+            'action' => 'reminder_exercise',
+        ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,7 +24,6 @@ use App\Http\Controllers\Api\WebAdmin\GeneralInfoController as AdminGeneralInfoC
 use App\Http\Controllers\Api\AppMobile\AuthController;
 use App\Http\Controllers\Api\AppMobile\ActivityController;
 use App\Http\Controllers\Api\AppMobile\CollaboratorController;
-use App\Http\Controllers\Api\AppMobile\DeviceTokenController;
 use App\Http\Controllers\Api\AppMobile\NotificationController as MobileNotificationController;
 use App\Http\Controllers\Api\AppMobile\GeneralInfoController;
 
@@ -108,7 +107,6 @@ Route::prefix('app')->group(function () {
         Route::post('user/photo',          [AuthController::class, 'updatePhoto']);
         Route::post('user/change-password', [AuthController::class, 'changePassword']);
 
-        Route::post('device-tokens', [DeviceTokenController::class, 'store']);
         Route::get('notifications', [MobileNotificationController::class, 'index']);
         Route::post('notifications/{id}/read', [MobileNotificationController::class, 'markAsRead']);
         Route::get('info', [GeneralInfoController::class, 'index']);


### PR DESCRIPTION
## Summary
- drop firebase channel from `EjercicioReminder` and use Laravel database notifications
- remove unused `DeviceTokenController` route

## Testing
- `composer --version` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ecfacbcac83289c1982a48ef391fe