### PR TITLE
Switch to internal notifications

### DIFF
--- a/app/Http/Controllers/Api/AppMobile/NotificationController.php
+++ b/app/Http/Controllers/Api/AppMobile/NotificationController.php
@@ -21,4 +21,13 @@ class NotificationController extends Controller
 
         return response()->json(['status' => 'ok']);
     }
+
+    public function destroy(Request $request, $id)
+    {
+        $user = $request->user();
+        $notification = $user->notifications()->findOrFail($id);
+        $notification->delete();
+
+        return response()->json(['status' => 'ok']);
+    }
 }

--- a/app/Http/Controllers/Api/WebAdmin/NotificationController.php
+++ b/app/Http/Controllers/Api/WebAdmin/NotificationController.php
@@ -11,15 +11,17 @@ class NotificationController extends Controller
     public function send(Request $req)
     {
         $data = $req->validate([
-          'title'=>'required|string',
-          'body'=>'required|string',
-          'filter'=>'required|string',
+            'title'   => 'required|string',
+            'body'    => 'required|string',
+            'filter'  => 'required|string',
+            'user_id' => 'nullable|integer',
         ]);
 
-        $users = match($data['filter']) {
-          'all'   => User::all(),
-          'koala' => User::where('team','KoalaFit')->get(),
-          default => User::where('id',$data['filter'])->get(),
+        $users = match ($data['filter']) {
+            'all'   => User::all(),
+            'koala' => User::where('team', 'KoalaFit')->get(),
+            'user'  => User::where('id', $data['user_id'])->get(),
+            default => User::where('id', $data['filter'])->get(),
         };
 
         foreach ($users as $u) {

--- a/app/Notifications/EjercicioReminder.php
+++ b/app/Notifications/EjercicioReminder.php
@@ -1,24 +1,24 @@
 <?php
 // app/Notifications/EjercicioReminder.php
 namespace App\Notifications;
+
 use Illuminate\Notifications\Notification;
-use NotificationChannels\Fcm\FcmChannel;
-use NotificationChannels\Fcm\FcmMessage;
-use NotificationChannels\Fcm\Resources\Notification as FcmNotif;
 
 class EjercicioReminder extends Notification
 {
     public function __construct(protected $title, protected $body) {}
 
-    public function via($notifiable) { return [FcmChannel::class]; }
-
-    public function toFcm($notifiable)
+    public function via($notifiable)
     {
-        return FcmMessage::create()
-            ->setNotification(FcmNotif::create()
-                ->setTitle($this->title)
-                ->setBody($this->body)
-            )
-            ->setData(['action'=>'reminder_exercise']);
+        return ['database'];
+    }
+
+    public function toArray($notifiable)
+    {
+        return [
+            'title'  => $this->title,
+            'body'   => $this->body,
+            'action' => 'reminder_exercise',
+        ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,7 +24,6 @@ use App\Http\Controllers\Api\WebAdmin\GeneralInfoController as AdminGeneralInfoC
 use App\Http\Controllers\Api\AppMobile\AuthController;
 use App\Http\Controllers\Api\AppMobile\ActivityController;
 use App\Http\Controllers\Api\AppMobile\CollaboratorController;
-use App\Http\Controllers\Api\AppMobile\DeviceTokenController;
 use App\Http\Controllers\Api\AppMobile\NotificationController as MobileNotificationController;
 use App\Http\Controllers\Api\AppMobile\GeneralInfoController;
 
@@ -108,9 +107,9 @@ Route::prefix('app')->group(function () {
         Route::post('user/photo',          [AuthController::class, 'updatePhoto']);
         Route::post('user/change-password', [AuthController::class, 'changePassword']);
 
-        Route::post('device-tokens', [DeviceTokenController::class, 'store']);
         Route::get('notifications', [MobileNotificationController::class, 'index']);
         Route::post('notifications/{id}/read', [MobileNotificationController::class, 'markAsRead']);
+        Route::delete('notifications/{id}', [MobileNotificationController::class, 'destroy']);
         Route::get('info', [GeneralInfoController::class, 'index']);
 
     });


### PR DESCRIPTION
## Summary
- drop firebase channel from `EjercicioReminder` and use Laravel database notifications
- remove unused `DeviceTokenController` route
- support targeting specific users in admin send
- allow deleting notifications from mobile app

## Testing
- `composer --version` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ecfacbcac83289c1982a48ef391fe