### PR TITLE
Improve reward fairness

### DIFF
--- a/app/Observers/ActivityObserver.php
+++ b/app/Observers/ActivityObserver.php
@@ -32,12 +32,21 @@ class ActivityObserver
             ? $activity->duration * 60
             : $activity->duration;
 
-        // 1) Cumplió pasos **y** minutos activos?
-        if (
-            $activity->steps >= $metaSteps
-            && $durationMinutes >= $metaMins
-        ) {
+        // 1) Cumplió pasos o minutos activos?
+        $stepsMet  = $activity->steps >= $metaSteps;
+        $minsMet   = $durationMinutes >= $metaMins;
+
+        if ($stepsMet && $minsMet) {
+            // Ambos criterios se cumplen
             $awarded += 10;
+        } else {
+            // Bono parcial por cumplir solo uno de los criterios
+            if ($stepsMet) {
+                $awarded += 5;
+            }
+            if ($minsMet) {
+                $awarded += 5;
+            }
         }
 
         // 2) Evidencia (foto o ubicación)


### PR DESCRIPTION
## Summary
- adjust Fitcoin reward logic for activities to give partial credit when only step or time goals are met

## Testing
- `vendor/bin/phpunit --stop-on-failure` *(fails: `vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686c0f181f0c832888d7216451073334