### PR TITLE
Add admin ability to invalidate activities

### DIFF
--- a/app/Http/Controllers/Api/WebAdmin/ActivityController.php
+++ b/app/Http/Controllers/Api/WebAdmin/ActivityController.php
@@ -5,10 +5,18 @@ namespace App\Http\Controllers\Api\WebAdmin;
 use App\Http\Controllers\Controller;
 use App\Models\Activity;
 use App\Models\User;
+use App\Services\FitcoinService;
+use App\Models\FitcoinTransaction;
 use Illuminate\Http\Request;
 
 class ActivityController extends Controller
 {
+    protected $fitcoin;
+
+    public function __construct(FitcoinService $fitcoin)
+    {
+        $this->fitcoin = $fitcoin;
+    }
     /**
      * GET /api/webadmin/activities
      *     ?user_id=   filtra por usuario
@@ -51,7 +59,49 @@ class ActivityController extends Controller
             $user->activities()            // relación inversa
                  ->with('user')
                  ->latest()
-                 ->paginate($perPage)
+                ->paginate($perPage)
         );
+    }
+
+    /**
+     * PATCH /api/webadmin/activities/{activity}/validate
+     * Cambia el estado de validación de una actividad y ajusta las CoinFits.
+     */
+    public function updateValidity(Request $request, Activity $activity)
+    {
+        $data = $request->validate(['is_valid' => 'required|boolean']);
+
+        $col = $activity->user->colaborator;
+        $tx = null;
+        if ($col) {
+            $tx = FitcoinTransaction::where('fitcoin_account_id', $col->fitcoinAccount->id ?? 0)
+                ->where('description', "Actividad ID {$activity->id}")
+                ->first();
+        }
+
+        // Invalidar
+        if ($activity->is_valid && $data['is_valid'] === false) {
+            $activity->is_valid = false;
+            $activity->save();
+
+            if ($col && $tx) {
+                $this->fitcoin->award($col, -$tx->amount, "Invalidación actividad ID {$activity->id}");
+            }
+        }
+
+        // Revalidar
+        if (! $activity->is_valid && $data['is_valid'] === true) {
+            $activity->is_valid = true;
+            $activity->save();
+
+            if ($col && ! $tx) {
+                $amount = $this->fitcoin->calculateActivityReward($activity, $col);
+                if ($amount > 0) {
+                    $this->fitcoin->award($col, $amount, "Actividad ID {$activity->id}");
+                }
+            }
+        }
+
+        return response()->json(['message' => 'Actividad actualizada']);
     }
 }

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -25,6 +25,7 @@ class Activity extends Model
         'notes',
         'location_lat',
         'location_lng',
+        'is_valid',
     ];
 
     /** Estos atributos virtuales se incluirán automáticamente
@@ -41,6 +42,7 @@ class Activity extends Model
         'attachments'   => 'array',
         'location_lat'  => 'decimal:6',
         'location_lng'  => 'decimal:6',
+        'is_valid'      => 'boolean',
     ];
 
     // Relación con usuario

--- a/app/Observers/ActivityObserver.php
+++ b/app/Observers/ActivityObserver.php
@@ -22,33 +22,11 @@ class ActivityObserver
         $col = $activity->user->colaborator;
         if (! $col) return;
 
-        $awarded   = 0;
         $level     = $col->nivel_asignado;
         $metaSteps = config("coinfits.levels.{$level}.steps", 0);
         $metaMins  = config("coinfits.levels.{$level}.minutes", 0);
 
-        // Convertir la duración a minutos para la evaluación
-        $durationMinutes = $activity->duration_unit === 'horas'
-            ? $activity->duration * 60
-            : $activity->duration;
-
-        // 1) Cumplió pasos **y** minutos activos?
-        if (
-            $activity->steps >= $metaSteps
-            && $durationMinutes >= $metaMins
-        ) {
-            $awarded += 10;
-        }
-
-        // 2) Evidencia (foto o ubicación)
-        if ($activity->selfie_path || $activity->location_lat) {
-            $awarded += 2;
-        }
-
-        // 3) Superó la meta de pasos
-        if ($activity->steps > $metaSteps) {
-            $awarded += 3;
-        }
+        $awarded = $this->fitcoin->calculateActivityReward($activity, $col);
 
         if ($awarded > 0) {
             $this->fitcoin->award(

--- a/app/Services/FitcoinService.php
+++ b/app/Services/FitcoinService.php
@@ -2,6 +2,7 @@
 namespace App\Services;
 
 use App\Models\Colaborator;
+use App\Models\Activity;
 use App\Models\FitcoinAccount;
 use App\Models\FitcoinTransaction;
 
@@ -31,5 +32,32 @@ class FitcoinService
         $account->save();
 
         return $tx;
+    }
+
+    /**
+     * Calcula la recompensa que corresponde a una actividad para el colaborador.
+     */
+    public function calculateActivityReward(Activity $activity, Colaborator $col): int
+    {
+        $level     = $col->nivel_asignado;
+        $metaSteps = config("coinfits.levels.{$level}.steps", 0);
+        $metaMins  = config("coinfits.levels.{$level}.minutes", 0);
+
+        $durationMinutes = $activity->duration_unit === 'horas'
+            ? $activity->duration * 60
+            : $activity->duration;
+
+        $awarded = 0;
+        if ($activity->steps >= $metaSteps && $durationMinutes >= $metaMins) {
+            $awarded += 10;
+        }
+        if ($activity->selfie_path || $activity->location_lat) {
+            $awarded += 2;
+        }
+        if ($activity->steps > $metaSteps) {
+            $awarded += 3;
+        }
+
+        return $awarded;
     }
 }

--- a/database/migrations/2025_07_30_000005_add_is_valid_to_activities_table.php
+++ b/database/migrations/2025_07_30_000005_add_is_valid_to_activities_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->boolean('is_valid')->default(true)->after('location_lng');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->dropColumn('is_valid');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -71,6 +71,7 @@ Route::middleware('auth:sanctum')->prefix('webadmin')->group(function () {
     Route::post('logout', [UserController::class, 'logout']);
     Route::get('activities',                  [AdminActivityController::class, 'index']);
     Route::get('users/{user}/activities',     [AdminActivityController::class, 'byUser']);
+    Route::patch('activities/{activity}/validate', [AdminActivityController::class, 'updateValidity']);
     Route::get('stats', [DashboardController::class, 'index']);
 
     // Notifications


### PR DESCRIPTION
## Summary
- track whether an activity is valid
- centralize reward calculation in `FitcoinService`
- use new reward calculator from activity observer
- allow admins to invalidate/validate activities and automatically adjust Fitcoins
- expose new route for activity validation

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686c14309438832885ed47e0626fc2cb