### PR TITLE
Add level name synonyms

### DIFF
--- a/config/coinfits.php
+++ b/config/coinfits.php
@@ -5,5 +5,10 @@ return [
         'KoalaFit'  => ['steps' => 3000,  'minutes' => 20],
         'JaguarFit' => ['steps' => 6000,  'minutes' => 30],
         'HalconFit' => ['steps' => 10000, 'minutes' => 45],
-    ],
-];
+
+        // Soporte para nombres sin el sufijo "Fit"
+        'Koala'  => ['steps' => 3000,  'minutes' => 20],
+        'Jaguar' => ['steps' => 6000,  'minutes' => 30],
+        'Halcon' => ['steps' => 10000, 'minutes' => 45],
+        'Halcón' => ['steps' => 10000, 'minutes' => 45],
+    ],];


### PR DESCRIPTION
## Summary
- support alternative level names for `Koala`, `Jaguar` and `Halcon`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebb05534483288687cc7415277abb