### PR TITLE
Normalize level names

### DIFF
--- a/app/Observers/ActivityObserver.php
+++ b/app/Observers/ActivityObserver.php
@@ -4,7 +4,6 @@ namespace App\Observers;
 
 use App\Models\Activity;
 use App\Services\FitcoinService;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Carbon;
 use App\Models\FitcoinTransaction;
 
@@ -22,9 +21,9 @@ class ActivityObserver
         $col = $activity->user->colaborator;
         if (! $col) return;
 
-        $level     = $col->nivel_asignado;
-        $metaSteps = config("coinfits.levels.{$level}.steps", 0);
-        $metaMins  = config("coinfits.levels.{$level}.minutes", 0);
+        $meta = $this->fitcoin->getLevelMeta($col->nivel_asignado);
+        $metaSteps = $meta['steps'];
+        $metaMins  = $meta['minutes'];
 
         $awarded = $this->fitcoin->calculateActivityReward($activity, $col);
 

--- a/config/coinfits.php
+++ b/config/coinfits.php
@@ -5,5 +5,13 @@ return [
         'KoalaFit'  => ['steps' => 3000,  'minutes' => 20],
         'JaguarFit' => ['steps' => 6000,  'minutes' => 30],
         'HalconFit' => ['steps' => 10000, 'minutes' => 45],
+
+        // Soporte para nombres sin el sufijo "Fit"
+        'Koala'  => ['steps' => 3000,  'minutes' => 20],
+        'Jaguar' => ['steps' => 6000,  'minutes' => 30],
+        'Halcon' => ['steps' => 10000, 'minutes' => 45],
+        'Halcón' => ['steps' => 10000, 'minutes' => 45],
     ],
-];
+
+    // Límite máximo de CoinFits que se pueden obtener por día
+    'daily_limit' => 10,];

--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Activity;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ActivityFactory extends Factory
+{
+    protected $model = Activity::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'exercise_type' => 'walk',
+            'duration' => 10,
+            'duration_unit' => 'minutos',
+            'steps' => 0,
+            'is_valid' => true,
+        ];
+    }
+}
+

--- a/database/factories/ColaboratorFactory.php
+++ b/database/factories/ColaboratorFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Colaborator;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ColaboratorFactory extends Factory
+{
+    protected $model = Colaborator::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'nombre'  => $this->faker->name,
+            'nivel_asignado' => $this->faker->randomElement(['KoalaFit', 'JaguarFit', 'HalconFit']),
+        ];
+    }
+}
+

--- a/tests/Unit/FitcoinServiceTest.php
+++ b/tests/Unit/FitcoinServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Activity;
+use App\Models\Colaborator;
+use App\Services\FitcoinService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FitcoinServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_activity_reward_respects_daily_limit_and_meta()
+    {
+        $service = new FitcoinService();
+        $colaborator = Colaborator::factory()->create(['nivel_asignado' => 'KoalaFit']);
+
+        // Activity below meta but with evidencia
+        $activity = Activity::factory()->create([
+            'user_id' => $colaborator->user_id,
+            'duration' => 1,
+            'duration_unit' => 'minutos',
+            'selfie_path' => 'selfie.jpg',
+            'location_lat' => 1.0,
+        ]);
+
+        $reward = $service->calculateActivityReward($activity, $colaborator);
+        $this->assertEquals(1, $reward);
+
+        // Award the user to almost reach the limit
+        $service->award($colaborator, 9, 'setup');
+
+        // Another valid activity that meets meta
+        $activity2 = Activity::factory()->create([
+            'user_id' => $colaborator->user_id,
+            'duration' => 30,
+            'duration_unit' => 'minutos',
+            'steps' => 4000,
+            'selfie_path' => 'selfie2.jpg',
+            'location_lat' => 1.0,
+        ]);
+
+        $reward2 = $service->calculateActivityReward($activity2, $colaborator);
+        // Only one CoinFit should be left to reach the daily limit
+        $this->assertEquals(1, $reward2);
+    }
+
+    public function test_level_name_is_normalized()
+    {
+        $service = new FitcoinService();
+        $col = Colaborator::factory()->create(['nivel_asignado' => ' Halcón ']);
+
+        $activity = Activity::factory()->create([
+            'user_id' => $col->user_id,
+            'duration' => 1,
+            'duration_unit' => 'minutos',
+            'selfie_path' => 'a.jpg',
+            'location_lat' => 1.0,
+        ]);
+
+        // Meta no cumplida, debería otorgar sólo 1 por ser actividad corta
+        $reward = $service->calculateActivityReward($activity, $col);
+        $this->assertEquals(1, $reward);
+    }
+}


### PR DESCRIPTION
## Summary
- standardize collaborator level names before reward calculation
- apply normalized levels when granting weekly bonuses
- add unit test for level normalization
- cap rewards for short activities (<10 mins) at 1 CoinFit

## Testing
- ❌ `php -v`
- ❌ `./vendor/bin/phpunit --version`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686ebb05534483288687cc7415277abb